### PR TITLE
Simplify userdb access

### DIFF
--- a/src/buildconfig.ts
+++ b/src/buildconfig.ts
@@ -140,46 +140,14 @@ function is_testing() {
   return jest_worker_is_running || jest_imported || test_node_env;
 }
 
-function local_couchdb_protocol(): string {
-  const usehttps = process.env.REACT_APP_USE_HTTPS;
-  if (PROD_BUILD) {
-    return 'https';
-  } else if (
-    usehttps === '' ||
-    usehttps === undefined ||
-    FALSEY_STRINGS.includes(usehttps.toLowerCase())
-  ) {
-    return 'http';
-  } else if (TRUTHY_STRINGS.includes(usehttps.toLowerCase())) {
-    return 'https';
+function conductor_user_db(): string {
+  const userdb = process.env.FAIMS_USERDB;
+  const userdb_default = "http://localhost:5984/people";
+  if (userdb === '' || userdb === undefined) {
+    console.log('FAIMS_USERDB not set, using default');
+    return userdb_default;
   } else {
-    console.error('REACT_APP_USE_HTTPS badly defined, assuming false');
-    return 'http';
-  }
-}
-
-function local_couchdb_host(): string {
-  const host = process.env.REACT_APP_LOCAL_COUCHDB_HOST;
-  if (host === '' || host === undefined) {
-    return '10.80.11.44';
-  }
-  return host;
-}
-
-function local_couchdb_port(): number {
-  const port = process.env.REACT_APP_LOCAL_COUCHDB_PORT;
-  if (port === '' || port === undefined) {
-    if (PROD_BUILD) {
-      return 443;
-    }
-    return 5984;
-  }
-  try {
-    return parseInt(port);
-  } catch (err) {
-    console.error(err);
-    console.error('Falling back to default port');
-    return 5984;
+    return userdb;
   }
 }
 
@@ -200,13 +168,11 @@ function local_couchdb_auth(): undefined | {username: string; password: string} 
   }
 }
 
+export const CONDUCTOR_USER_DB = conductor_user_db();
 export const DIRECTORY_PROTOCOL = directory_protocol();
 export const DIRECTORY_HOST = directory_host();
 export const DIRECTORY_PORT = directory_port();
 export const DIRECTORY_AUTH = directory_auth();
-export const LOCAL_COUCHDB_PROTOCOL = local_couchdb_protocol();
-export const LOCAL_COUCHDB_HOST = local_couchdb_host();
-export const LOCAL_COUCHDB_PORT = local_couchdb_port();
 export const LOCAL_COUCHDB_AUTH = local_couchdb_auth();
 export const RUNNING_UNDER_TEST = is_testing();
 export const COMMIT_VERSION = commit_version();

--- a/src/couchdb/users.ts
+++ b/src/couchdb/users.ts
@@ -22,26 +22,25 @@
 import PouchDB from 'pouchdb';
 
 import {
-  LOCAL_COUCHDB_PROTOCOL,
-  LOCAL_COUCHDB_HOST,
-  LOCAL_COUCHDB_PORT,
+  CONDUCTOR_USER_DB,
   LOCAL_COUCHDB_AUTH,
 } from '../buildconfig';
 import {PouchUser} from '../datamodel/database';
 import type {CouchDBUsername} from '../authkeys/types';
-import {
-  ConnectionInfo_create_pouch,
-  local_pouch_options,
-  materializeConnectionInfo,
-} from '../sync/connection';
 
-const users_db: PouchDB.Database<PouchUser> = ConnectionInfo_create_pouch({
-  db_name: 'FAIMS3_users',
-  proto: LOCAL_COUCHDB_PROTOCOL,
-  host: LOCAL_COUCHDB_HOST,
-  port: LOCAL_COUCHDB_PORT,
-  auth: LOCAL_COUCHDB_AUTH,
-});
+function createUsersDB(): PouchDB.Database<PouchUser> {
+  const pouch_options: PouchDB.Configuration.RemoteDatabaseConfiguration = {};
+
+  if (LOCAL_COUCHDB_AUTH !== undefined) {
+    pouch_options.auth = LOCAL_COUCHDB_AUTH;
+  }
+  return new PouchDB(
+    CONDUCTOR_USER_DB,
+    pouch_options
+  );
+}
+
+const users_db = createUsersDB();
 
 export async function getUserByEmail(email: string): Promise<null | PouchUser> {
   const result = await users_db.find({


### PR DESCRIPTION
@Denubis If you set `FAIMS_USERDB=https://dev.db.faims.edu.au/people`, then the conductor should talk to the db correctly (FYI, couchdb names can only be lowercase, which is likely why FAIMS_users was failing).