### PR TITLE
Add environment variables for signing key config

### DIFF
--- a/src/buildconfig.ts
+++ b/src/buildconfig.ts
@@ -191,6 +191,36 @@ function signing_key_id(): string {
   }
 }
 
+function private_key_path(): string {
+  const key_path = process.env.FAIMS_CONDUCTOR_PRIVATE_KEY_PATH;
+  if (key_path === '' || key_path === undefined) {
+    console.log('FAIMS_CONDUCTOR_PRIVATE_KEY_PATH not set, using default');
+    return 'private_key.pem';
+  } else {
+    return key_path;
+  }
+}
+
+function public_key_path(): string {
+  const key_path = process.env.FAIMS_CONDUCTOR_PUBLIC_KEY_PATH;
+  if (key_path === '' || key_path === undefined) {
+    console.log('FAIMS_CONDUCTOR_PUBLIC_KEY_PATH not set, using default');
+    return 'public_key.pem';
+  } else {
+    return key_path;
+  }
+}
+
+function instance_name(): string {
+  const name = process.env.FAIMS_CONDUCTOR_INSTANCE_NAME;
+  if (name === '' || name === undefined) {
+    console.log('FAIMS_CONDUCTOR_INSTANCE_NAME not set, using default');
+    return 'test';
+  } else {
+    return name;
+  }
+}
+
 export const CONDUCTOR_USER_DB = conductor_user_db();
 export const DIRECTORY_PROTOCOL = directory_protocol();
 export const DIRECTORY_HOST = directory_host();
@@ -204,3 +234,6 @@ export const AUTOACTIVATE_PROJECTS = true; // for alpha, beta will change this
 export const REQUIRED_GROUP = required_group();
 export const CONDUCTOR_PORT = 8080;
 export const CONDUCTOR_KEY_ID = signing_key_id();
+export const CONDUCTOR_PRIVATE_KEY_PATH = private_key_path();
+export const CONDUCTOR_PUBLIC_KEY_PATH = public_key_path();
+export const CONDUCTOR_INSTANCE_NAME = instance_name();

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,13 @@ import PouchDBFind from 'pouchdb-find';
 
 import {auth_mechanisms, oauth_verify} from './authconfig';
 import {CleanOAuth2Strategy, dc_auth_profile} from './authhelpers';
-import {CONDUCTOR_KEY_ID, CONDUCTOR_PORT} from './buildconfig';
+import {
+  CONDUCTOR_KEY_ID,
+  CONDUCTOR_PORT,
+  CONDUCTOR_PUBLIC_KEY_PATH,
+  CONDUCTOR_PRIVATE_KEY_PATH,
+  CONDUCTOR_INSTANCE_NAME,
+} from './buildconfig';
 import {load_signing_key} from './authkeys/signing_keys';
 import {app} from './routes';
 import {add_auth_routes} from './auth_routes';
@@ -65,10 +71,10 @@ add_auth_routes(app, ['default']);
 async function initialize() {
   const signing_key = await load_signing_key({
     signing_algorithm: 'RS256',
-    instance_name: 'test',
+    instance_name: CONDUCTOR_INSTANCE_NAME,
     key_id: CONDUCTOR_KEY_ID,
-    public_key_file: 'public_key.pem',
-    private_key_file: 'private_key.pem',
+    public_key_file: CONDUCTOR_PUBLIC_KEY_PATH,
+    private_key_file: CONDUCTOR_PRIVATE_KEY_PATH,
   });
   app.set('faims3_token_signing_key', signing_key);
 }


### PR DESCRIPTION
The paths to the public and private keys can now be set, as well as the name to use in the issuer field.