### PR TITLE
On login error, send users to CAS logout

### DIFF
--- a/src/auth_routes.ts
+++ b/src/auth_routes.ts
@@ -43,7 +43,11 @@ export function add_auth_routes(app: any, handlers: any) {
         typeof req.query?.state === 'undefined'
       ) {
         passport.authenticate(handler)(req, res, (err?: {}) => {
-          throw err ?? Error('Authentication failed (next, no error)');
+          // Hack to avoid users getting caught when they're not in the right
+          // groups.
+          console.error('Authentication Error', err);
+          res.redirect('https://auth.datacentral.org.au/cas/logout');
+          //throw err ?? Error('Authentication failed (next, no error)');
         });
       } else {
         throw Error(

--- a/src/core.ts
+++ b/src/core.ts
@@ -47,4 +47,3 @@ app.use(passport.session());
 app.engine('handlebars', express_handlebars());
 app.set('view engine', 'handlebars');
 app.use(express.static('public'));
-

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -56,7 +56,7 @@ app.post(
 
 app.get('/auth/', (req, res) => {
   // Allow the user to decide what auth mechanism to use
-  res.render("auth");
+  res.render('auth');
 });
 
 app.get('/', async (req, res) => {


### PR DESCRIPTION
This avoids the case where users are stuck between logging in and being
rejected because they are not in the allowed groups. We need a longer
term fix for who gets access to tokens when with use other OAuth
providers, but this should be enough for now.