### PR TITLE
Add shortcut to log out from Data Central

### DIFF
--- a/src/auth_providers/data_central.ts
+++ b/src/auth_providers/data_central.ts
@@ -29,6 +29,7 @@ import {saveUserToDB} from '../couchdb/users';
 import {VerifyCallback, DoneFunction} from '../types';
 
 const MAIN_GROUPS = ['editor', 'public', 'moderator'];
+export const LOGOUT_URL = 'https://auth.datacentral.org.au/cas/logout';
 
 function ldap_group_to_group_name(group: string): string {
   const split_dn = group.split(',');

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -7,4 +7,5 @@
 </ul>
 <br/>
 <a href="/send-token/" class="btn btn-primary" style="background-color:#1B3E93;">Go back to App</a>
-<a href="/logout/" class="btn">Logout</a>
+<a href="/logout/" class="btn">Logout from conductor</a>
+<a href="https://auth.datacentral.org.au/cas/logout" class="btn">Logout from Data Central</a>


### PR DESCRIPTION
We need to clear the CAS ticket for a user to be fully logged out.