### PR TITLE
Use lowercase and trim for any DC usernames

### DIFF
--- a/src/auth_providers/data_central.ts
+++ b/src/auth_providers/data_central.ts
@@ -89,7 +89,7 @@ export function oauth_verify(
   );
   const name = profile.attributes.displayName;
   const user: Express.User = {
-    user_id: profile.id,
+    user_id: profile.id.toLowerCase().trim(),
     name: name,
     roles: roles,
     other_props: profile,


### PR DESCRIPTION
This comes from the way usernames are handled internally. This should
avoid problems flagged in FAIMS3-431, but we'll need a long-term plan
for handling multiple providers with different case-sensitivity rules.