### PR TITLE
Add user's name to token

### DIFF
--- a/src/auth_routes.ts
+++ b/src/auth_routes.ts
@@ -54,7 +54,7 @@ export function add_auth_routes(app: any, handlers: any) {
     // Allow the user to decide what auth mechanism to use
     const available_provider_info = [];
     for (const handler of handlers) {
-      console.debug("handlers", handlers);
+      console.debug('handlers', handlers);
       available_provider_info.push({
         label: handler,
         name: AVAILABLE_AUTH_PROVIDER_DISPLAY_INFO[handler].name,

--- a/src/authkeys/create.ts
+++ b/src/authkeys/create.ts
@@ -27,10 +27,12 @@ import type {SigningKey} from './types';
 export async function create_auth_key(
   username: CouchDBUsername,
   roles: CouchDBUserRoles,
-  signing_key: SigningKey
+  signing_key: SigningKey,
+  name: string
 ) {
   const jwt = await new SignJWT({
     '_couchdb.roles': roles,
+    name: name,
   })
     .setProtectedHeader({
       alg: signing_key.alg,

--- a/src/authkeys/index.test.ts
+++ b/src/authkeys/index.test.ts
@@ -95,11 +95,16 @@ describe('roundtrip creating and reading token', () => {
     [
       fc.fullUnicodeString(), // username name
       fc.array(fc.fullUnicodeString()), // roles
+      fc.fullUnicodeString(), // name
     ],
-    async (username: CouchDBUsername, roles: CouchDBUserRoles) => {
+    async (
+      username: CouchDBUsername,
+      roles: CouchDBUserRoles,
+      name: string
+    ) => {
       const signing_key = await get_test_key();
 
-      return create_auth_key(username, roles, signing_key)
+      return create_auth_key(username, roles, signing_key, name)
         .then(token => {
           return read_auth_key(token, signing_key);
         })
@@ -107,6 +112,7 @@ describe('roundtrip creating and reading token', () => {
           console.log(token_props);
           expect(username).toBe(token_props.username);
           expect(roles).toStrictEqual(token_props.roles);
+          expect(name).toStrictEqual(token_props.name);
           expect(INSTANCE_NAME).toBe(token_props.instance_name);
           expect(KEY_ID).toBe(token_props.key_id);
         });

--- a/src/authkeys/read.ts
+++ b/src/authkeys/read.ts
@@ -35,6 +35,7 @@ export async function read_auth_key(token: string, signing_key: SigningKey) {
   return {
     username: payload.sub,
     roles: payload['_couchdb.roles'],
+    name: payload['name'],
     instance_name: payload.iss,
     issued_at: payload.iat,
     key_id: protectedHeader.kid,

--- a/src/authkeys/user.ts
+++ b/src/authkeys/user.ts
@@ -20,7 +20,7 @@
  */
 
 import {create_auth_key} from './create';
-import type {CouchDBUsername, CouchDBUserRoles} from '../datamodel/users';
+import type {CouchDBUsername} from '../datamodel/users';
 import type {SigningKey} from './types';
 import {get_couchdb_user_from_username} from '../couchdb/users';
 
@@ -29,20 +29,14 @@ export async function get_user_auth_token(
   signing_key: SigningKey
 ) {
   console.debug('Getting user roles for', username);
-  const roles = await get_couchdb_user_roles(username);
-  console.debug('Getting user token for', username, roles);
-  const token = await create_auth_key(username, roles, signing_key);
-  console.debug('Returning user token for', username, token);
-  return token;
-}
-
-async function get_couchdb_user_roles(
-  username: CouchDBUsername
-): Promise<CouchDBUserRoles> {
   const user = await get_couchdb_user_from_username(username);
   if (user === null) {
-    console.log('No roles found for', username);
-    return [];
+    throw Error(`No such user ${username}`);
   }
-  return user.roles;
+  const roles = user.roles ?? [];
+  const name = user.name ?? username;
+  console.debug('Getting user token for', username, roles, name);
+  const token = await create_auth_key(username, roles, signing_key, name);
+  console.debug('Returning user token for', username, token);
+  return token;
 }


### PR DESCRIPTION
This means we can display a more user-understandable name in places,
rather than a username, which may be less clear.