### PR TITLE
Revert "Update passport to 0.6.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/jsonwebtoken": "8.5.9",
         "@types/node": "18.7.23",
         "@types/nodemailer": "6.4.5",
-        "@types/passport": "1.0.11",
+        "@types/passport": "1.0.7",
         "@types/passport-google-oauth20": "2.0.11",
         "@types/passport-oauth2": "1.4.11",
         "@types/pouchdb": "6.4.0",
@@ -38,7 +38,7 @@
         "jsonwebtoken": "8.5.1",
         "nodemailer": "6.7.8",
         "oauth": "0.10.0",
-        "passport": "0.6.0",
+        "passport": "0.5.3",
         "passport-google-oauth20": "2.0.0",
         "passport-oauth2": "1.6.1",
         "pouchdb": "7.3.0",
@@ -50,6 +50,7 @@
         "uuid": "9.0.0"
       },
       "devDependencies": {
+        "@types/expect": "^24.3.0",
         "@types/mocha": "^10.0.0",
         "dotenv": "^16.0.2",
         "env-cmd": "^10.1.0",
@@ -1224,6 +1225,16 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/expect": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-24.3.0.tgz",
+      "integrity": "sha512-aq5Z+YFBz5o2b6Sp1jigx5nsmoZMK5Ceurjwy6PZmRv7dEi1jLtkARfvB1ME+OXJUG+7TZUDcv3WoCr/aor6dQ==",
+      "deprecated": "This is a stub types definition. expect provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "expect": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
@@ -1362,9 +1373,9 @@
       }
     },
     "node_modules/@types/passport": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.11.tgz",
-      "integrity": "sha512-pz1cx9ptZvozyGKKKIPLcVDVHwae4hrH5d6g5J+DkMRRjR3cVETb4jMabhXAUbg3Ov7T22nFHEgaK2jj+5CBpw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.7.tgz",
+      "integrity": "sha512-JtswU8N3kxBYgo+n9of7C97YQBT+AYPP2aBfNGTzABqPAZnK/WOAaKfh3XesUYMZRrXFuoPc2Hv0/G/nQFveHw==",
       "dependencies": {
         "@types/express": "*"
       }
@@ -6672,13 +6683,12 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"
@@ -9648,6 +9658,15 @@
         "@types/ms": "*"
       }
     },
+    "@types/expect": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-24.3.0.tgz",
+      "integrity": "sha512-aq5Z+YFBz5o2b6Sp1jigx5nsmoZMK5Ceurjwy6PZmRv7dEi1jLtkARfvB1ME+OXJUG+7TZUDcv3WoCr/aor6dQ==",
+      "dev": true,
+      "requires": {
+        "expect": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
@@ -9786,9 +9805,9 @@
       }
     },
     "@types/passport": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.11.tgz",
-      "integrity": "sha512-pz1cx9ptZvozyGKKKIPLcVDVHwae4hrH5d6g5J+DkMRRjR3cVETb4jMabhXAUbg3Ov7T22nFHEgaK2jj+5CBpw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.7.tgz",
+      "integrity": "sha512-JtswU8N3kxBYgo+n9of7C97YQBT+AYPP2aBfNGTzABqPAZnK/WOAaKfh3XesUYMZRrXFuoPc2Hv0/G/nQFveHw==",
       "requires": {
         "@types/express": "*"
       }
@@ -13708,13 +13727,12 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "requires": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       }
     },
     "passport-google-oauth20": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/jsonwebtoken": "8.5.9",
     "@types/node": "18.7.23",
     "@types/nodemailer": "6.4.5",
-    "@types/passport": "1.0.11",
+    "@types/passport": "1.0.7",
     "@types/passport-google-oauth20": "2.0.11",
     "@types/passport-oauth2": "1.4.11",
     "@types/pouchdb": "6.4.0",
@@ -45,7 +45,7 @@
     "jsonwebtoken": "8.5.1",
     "nodemailer": "6.7.8",
     "oauth": "0.10.0",
-    "passport": "0.6.0",
+    "passport": "0.5.3",
     "passport-google-oauth20": "2.0.0",
     "passport-oauth2": "1.6.1",
     "pouchdb": "7.3.0",
@@ -57,6 +57,7 @@
     "uuid": "9.0.0"
   },
   "devDependencies": {
+    "@types/expect": "^24.3.0",
     "@types/mocha": "^10.0.0",
     "dotenv": "^16.0.2",
     "env-cmd": "^10.1.0",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -227,12 +227,9 @@ app.get('/', async (req, res) => {
 
 app.get('/logout/', (req, res) => {
   if (req.user) {
-    req.logout(() => {
-      res.redirect('/');
-    });
-  } else {
-    res.redirect('/');
+    req.logout();
   }
+  res.redirect('/');
 });
 
 app.get('/send-token/', (req, res) => {


### PR DESCRIPTION
This reverts commit 13ced8b0c00bb26edca6fc947a9c9ecfa5642b45. This is needed as 0.6.0 is broken, and needs a fix to how session handling works. This is covered in
https://github.com/jaredhanson/passport/issues/904