### PR TITLE
Add done button suggestion to send-auth page

### DIFF
--- a/views/send-token.handlebars
+++ b/views/send-token.handlebars
@@ -50,6 +50,8 @@ fetch(
 there's been some issue connecting to the app. See the user documentation for
 how to resolve this, but here's some starting points:</p>
 <ul>
+<li>If you've loaded this page in the app, see if there's a “Done” button which
+will send you back to the main app.</li>
 <li>On <a href="{{ android_url }}">Android</a> and
 <a href="{{ ios_url }}">iOS</a>,
 make sure you've installed the app on to your device.</li>


### PR DESCRIPTION
We can iterate on the wording, but should hopefully get users to start looking for the button to close the webview.

For FAIMS3-686.