### PR TITLE
Fix zip download problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fix": "gts fix",
     "prestart": "npm run-script compile",
     "start": "node .",
+    "local": "env-cmd nodemon --ignore build --ext ts --exec 'tsc --incremental && node .'",
     "watch": "nodemon --ignore build --ext ts --exec 'tsc --incremental && node .'",
     "initdb": "env-cmd node scripts/initialise.js",
     "load-notebooks": "env-cmd node scripts/loadNotebook.js ./notebooks/*.json",

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -551,7 +551,7 @@ describe('API tests', () => {
         .expect('Content-Type', 'application/zip')
         .expect(response => {
           const zipContent = response.text;
-          // check for _1 filename which should be there because of 
+          // check for _1 filename which should be there because of
           // a clash of names
           expect(zipContent).to.contain(
             'take-photo/DuplicateHRID-take-photo_1.png'

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -548,7 +548,15 @@ describe('API tests', () => {
         .get('/api/notebooks/1693291182736-campus-survey-demo/FORM2.zip')
         .set('Authorization', `Bearer ${adminToken}`)
         .expect(200)
-        .expect('Content-Type', 'application/zip');
+        .expect('Content-Type', 'application/zip')
+        .expect(response => {
+          const zipContent = response.text;
+          // check for _1 filename which should be there because of 
+          // a clash of names
+          expect(zipContent).to.contain(
+            'take-photo/DuplicateHRID-take-photo_1.png'
+          );
+        });
     }
   });
 


### PR DESCRIPTION
Duplicate record HRIDs result in duplicate filenames and so files overwritten in zip. Also a problem with very small zip files not downloading.


Signed-off-by: Steve Cassidy <steve.cassidy@mq.edu.au>